### PR TITLE
Add a main script to run the app with uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ packages = ["spotKeys"]
 [tool.uv.sources]
 tolk = { path = "vendor/tolk-python" }
 
+[project.scripts]
+main = "spotKeys.main:main"
+
 [tool.ruff]
 line-length = 120
 output-format = "grouped"


### PR DESCRIPTION
#### Description
This PR updates the `pyproject.toml` to run the app with a shorthand, `uv run main` command.

#### Resolved Issues
* Closes #31