### PR TITLE
Implement separate track detail retrieval controls

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -12,6 +12,6 @@
 			"n": "getCurrentTrackName",
 			"r": "getCurrentTrackArtistNames",
 			"a": "getCurrentTrackAlbumName",
-			"i": "getLongTrackDescription"
+			"i": "getCurrentTrackDetails"
 		}
 	}

--- a/data/config.json
+++ b/data/config.json
@@ -9,6 +9,9 @@
 			"[": "rewind",
 			"]": "fastForward",
 			"m": "muteOrUnmute",
+			"n": "getCurrentTrackName",
+			"r": "getCurrentTrackArtistNames",
+			"a": "getCurrentTrackAlbumName",
 			"i": "getLongTrackDescription"
 		}
 	}

--- a/data/config.json
+++ b/data/config.json
@@ -9,6 +9,6 @@
 			"[": "rewind",
 			"]": "fastForward",
 			"m": "muteOrUnmute",
-			"t": "getTrackDescription"
+			"i": "getLongTrackDescription"
 		}
 	}

--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -200,6 +200,27 @@ def muteOrUnmute(currentPlaybackContext) -> None:
 
 
 @checkForPlayingMedia
+def getCurrentTrackName(currentPlaybackContext) -> None:
+	"""Gets the name of the currently-playing track."""
+
+	speech.say(getTrackName(currentPlaybackContext))
+
+
+@checkForPlayingMedia
+def getCurrentTrackArtistNames(currentPlaybackContext) -> None:
+	"""Get the list of artist name(s) of the currently-playing track."""
+
+	speech.say(','.join(getTrackArtistNames(currentPlaybackContext)))
+
+
+@checkForPlayingMedia
+def getCurrentTrackAlbumName(currentPlaybackContext) -> None:
+	"""Gets the album name of the currently-playing track."""
+
+	speech.say(getTrackAlbumName(currentPlaybackContext))
+
+
+@checkForPlayingMedia
 def getLongTrackDescription(currentPlaybackContext) -> None:
 	"""
 	Gets the current track info as a single string, including:

--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -50,19 +50,19 @@ def checkForPlayingMedia(function):
 
 
 def getTrackName(currentPlaybackContext) -> None:
-	"""Gets the name of the currently-playing track."""
+	"""Gets the name of the track from the given playback context."""
 
 	return currentPlaybackContext['item']['name']
 
 
 def getTrackArtistNames(currentPlaybackContext) -> None:
-	"""Gets a list of the artist name(s) of the currently-playing track."""
+	"""Gets a list of the artist name(s) of the track from the given playback context."""
 
 	return [artist['name'] for artist in currentPlaybackContext['item']['artists']]
 
 
 def getTrackAlbumName(currentPlaybackContext) -> None:
-	"""Gets the album name of the currently-playing track."""
+	"""Gets the album name of the track from the given playback context."""
 
 	return currentPlaybackContext['item']['album']['name']
 

--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -177,7 +177,7 @@ def muteOrUnmute(currentPlaybackContext) -> None:
 
 
 @checkForPlayingMedia
-def getTrackDescription(currentPlaybackContext) -> None:
+def getLongTrackDescription(currentPlaybackContext) -> None:
 	"""
 	Gets the current track info as a single string, including:
 	* Track name;

--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -1,4 +1,4 @@
-"""Defines user-facing controls to use spotifyHandler."""
+"""Defines user-facing controls to use Spotify."""
 
 from functools import wraps
 

--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -221,16 +221,16 @@ def getCurrentTrackAlbumName(currentPlaybackContext) -> None:
 
 
 @checkForPlayingMedia
-def getLongTrackDescription(currentPlaybackContext) -> None:
+def getCurrentTrackDetails(currentPlaybackContext) -> None:
 	"""
-	Gets the current track info as a single string, including:
+	Gets the current track details as a single announcement, including:
 	* Track name;
 	* Artist names; and
 	* Album name.
 	"""
 
 	trackName = getTrackName(currentPlaybackContext)
-	artistNames = getTrackArtistNames(currentPlaybackContext)
+	artistNames = ','.join(getTrackArtistNames(currentPlaybackContext))
 	albumName = getTrackAlbumName(currentPlaybackContext)
 
 	speech.say(f'{trackName} by {artistNames} from {albumName}')

--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -44,6 +44,29 @@ def checkForPlayingMedia(function):
 	return wrapper
 
 
+# The following functions do not check if media is playing
+# They simply return data from a given playback context payload
+# They also can be used to compose larger forms of text like long trac descriptions
+
+
+def getTrackName(currentPlaybackContext) -> None:
+	"""Gets the name of the currently-playing track."""
+
+	return currentPlaybackContext['item']['name']
+
+
+def getTrackArtistNames(currentPlaybackContext) -> None:
+	"""Gets a list of the artist name(s) of the currently-playing track."""
+
+	return [artist['name'] for artist in currentPlaybackContext['item']['artists']]
+
+
+def getTrackAlbumName(currentPlaybackContext) -> None:
+	"""Gets the album name of the currently-playing track."""
+
+	return currentPlaybackContext['item']['album']['name']
+
+
 @checkForPlayingMedia
 def playOrPause(currentPlaybackContext) -> None:
 	"""
@@ -183,12 +206,10 @@ def getLongTrackDescription(currentPlaybackContext) -> None:
 	* Track name;
 	* Artist names; and
 	* Album name.
-
-	Artist names are separated by commas.
 	"""
 
-	trackName = currentPlaybackContext['item']['name']
-	artistNames = ', '.join(artist['name'] for artist in currentPlaybackContext['item']['artists'])
-	albumName = currentPlaybackContext['item']['album']['name']
+	trackName = getTrackName(currentPlaybackContext)
+	artistNames = getTrackArtistNames(currentPlaybackContext)
+	albumName = getTrackAlbumName(currentPlaybackContext)
 
 	speech.say(f'{trackName} by {artistNames} from {albumName}')

--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -49,19 +49,19 @@ def checkForPlayingMedia(function):
 # They also can be used to compose larger forms of text like long trac descriptions
 
 
-def getTrackName(currentPlaybackContext) -> None:
+def getTrackName(currentPlaybackContext) -> str:
 	"""Gets the name of the track from the given playback context."""
 
 	return currentPlaybackContext['item']['name']
 
 
-def getTrackArtistNames(currentPlaybackContext) -> None:
+def getTrackArtistNames(currentPlaybackContext) -> list:
 	"""Gets a list of the artist name(s) of the track from the given playback context."""
 
 	return [artist['name'] for artist in currentPlaybackContext['item']['artists']]
 
 
-def getTrackAlbumName(currentPlaybackContext) -> None:
+def getTrackAlbumName(currentPlaybackContext) -> str:
 	"""Gets the album name of the track from the given playback context."""
 
 	return currentPlaybackContext['item']['album']['name']

--- a/spotKeys/keyboardHandler.py
+++ b/spotKeys/keyboardHandler.py
@@ -19,6 +19,9 @@ DEFAULT_KEYBOARD_SHORTCUTS = {
 	'[': 'rewind',
 	']': 'fastForward',
 	'm': 'muteOrUnmute',
+	'n': 'getCurrentTrackName',
+	'r': 'getCurrentTrackArtistNames',
+	'a': 'getCurrentTrackAlbumName',
 	'i': 'getLongTrackDescription',
 }
 
@@ -34,6 +37,9 @@ functionsToControls = {
 	'rewind': controls.rewind,
 	'fastForward': controls.fastForward,
 	'muteOrUnmute': controls.muteOrUnmute,
+	'getCurrentTrackName': controls.getCurrentTrackName,
+	'getCurrentTrackArtistNames': controls.getCurrentTrackArtistNames,
+	'getCurrentTrackAlbumName': controls.getCurrentTrackAlbumName,
 	'getLongTrackDescription': controls.getLongTrackDescription,
 }
 

--- a/spotKeys/keyboardHandler.py
+++ b/spotKeys/keyboardHandler.py
@@ -19,7 +19,7 @@ DEFAULT_KEYBOARD_SHORTCUTS = {
 	'[': 'rewind',
 	']': 'fastForward',
 	'm': 'muteOrUnmute',
-	't': 'getTrackDescription',
+	'i': 'getLongTrackDescription',
 }
 
 DEFAULT_QUIT_KEYBOARD_SHORTCUT = f'{DEFAULT_KEYBOARD_MODIFIERS}+q'
@@ -34,7 +34,7 @@ functionsToControls = {
 	'rewind': controls.rewind,
 	'fastForward': controls.fastForward,
 	'muteOrUnmute': controls.muteOrUnmute,
-	'getTrackDescription': controls.getTrackDescription,
+	'getLongTrackDescription': controls.getLongTrackDescription,
 }
 
 DEFAULT_JSON_CONFIG_PATH = 'data/config.json'

--- a/spotKeys/keyboardHandler.py
+++ b/spotKeys/keyboardHandler.py
@@ -22,7 +22,7 @@ DEFAULT_KEYBOARD_SHORTCUTS = {
 	'n': 'getCurrentTrackName',
 	'r': 'getCurrentTrackArtistNames',
 	'a': 'getCurrentTrackAlbumName',
-	'i': 'getLongTrackDescription',
+	'i': 'getCurrentTrackDetails',
 }
 
 DEFAULT_QUIT_KEYBOARD_SHORTCUT = f'{DEFAULT_KEYBOARD_MODIFIERS}+q'
@@ -40,7 +40,7 @@ functionsToControls = {
 	'getCurrentTrackName': controls.getCurrentTrackName,
 	'getCurrentTrackArtistNames': controls.getCurrentTrackArtistNames,
 	'getCurrentTrackAlbumName': controls.getCurrentTrackAlbumName,
-	'getLongTrackDescription': controls.getLongTrackDescription,
+	'getCurrentTrackDetails': controls.getCurrentTrackDetails,
 }
 
 DEFAULT_JSON_CONFIG_PATH = 'data/config.json'


### PR DESCRIPTION
### Description
This PR adds three controls:
1. `getCurrentTrackName`;
2. `getCurrentTrackArtistNames`; and
3. `getCurrentTrackAlbumName`.

#### Resolved Issues
* Closes #23