### PR TITLE
Persist Spotipy cache in user's home directory

### DIFF
--- a/spotKeys/spotify.py
+++ b/spotKeys/spotify.py
@@ -1,10 +1,15 @@
 """Sets up Spotify-related config."""
 
 import os
+from pathlib import Path
 
 import environs
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
+
+# Default values
+USER_HOME_DIRECTORY = Path.home()
+SPOTIPY_CACHE_PATH = USER_HOME_DIRECTORY / '.spot_keys_cache'
 
 # Read environment variables from `.env`
 environs.Env().read_env()
@@ -17,5 +22,6 @@ SPOTIFY_HANDLER = spotipy.Spotify(
 		client_secret=os.getenv('CLIENT_SECRET'),
 		redirect_uri=os.getenv('REDIRECT_URI'),
 		scope=os.getenv('SCOPES'),
+		cache_path=SPOTIPY_CACHE_PATH,
 	)
 )


### PR DESCRIPTION
#### Description
This PR changes where Spotipy reads from and writes its cache file to. It is now using `.spot_keys_cache` in the user's home directory.

#### Resolved Issues
* Closes #39