### PR TITLE
Add like/dislike track functionality

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -1,5 +1,5 @@
 {
-		"keyboardModifiers": "alt+shift",
+		"keyboardModifiers": "alt+ctrl+shift",
 		"keyboardShortcuts": {
 			"p": "playOrPause",
 			"left": "previousTrack",
@@ -12,6 +12,8 @@
 			"n": "getCurrentTrackName",
 			"r": "getCurrentTrackArtistNames",
 			"a": "getCurrentTrackAlbumName",
-			"i": "getCurrentTrackDetails"
+			"i": "getCurrentTrackDetails",
+			"l": "likeCurrentTrack",
+			"d": "dislikeCurrentTrack"
 		}
 	}

--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -214,6 +214,34 @@ def increaseVolume(currentPlaybackContext, percentage=VOLUME_PERCENTAGE_INTERVAL
 
 
 @checkForPlayingMedia
+def likeCurrentTrack(currentPlaybackContext) -> None:
+	"""Adds the currently-playing track to the user's Liked Songs."""
+	track = currentPlaybackContext['item']
+	trackID = track['id']
+	trackName = track['name']
+
+	if spotifyHandler.current_user_saved_tracks_contains([trackID])[0]:
+		speech.say(f'{trackName} is already in your Liked Songs')
+	else:
+		spotifyHandler.current_user_saved_tracks_add([trackID])
+		speech.say(f'Added {trackName} to Liked Songs')
+
+
+@checkForPlayingMedia
+def dislikeCurrentTrack(currentPlaybackContext) -> None:
+	"""Removes the currently-playing track from the user's Liked Songs."""
+	track = currentPlaybackContext['item']
+	trackID = track['id']
+	trackName = track['name']
+
+	if not spotifyHandler.current_user_saved_tracks_contains([trackID])[0]:
+		speech.say(f'{trackName} is not in your Liked Songs')
+	else:
+		spotifyHandler.current_user_saved_tracks_delete([trackID])
+		speech.say(f'Removed {trackName} from Liked Songs')
+
+
+@checkForPlayingMedia
 def muteOrUnmute(currentPlaybackContext) -> None:
 	"""
 	Mutes or unmutes the current track dynamically.

--- a/spotKeys/keyboardHandler.py
+++ b/spotKeys/keyboardHandler.py
@@ -23,6 +23,8 @@ DEFAULT_KEYBOARD_SHORTCUTS = {
 	'r': 'getCurrentTrackArtistNames',
 	'a': 'getCurrentTrackAlbumName',
 	'i': 'getCurrentTrackDetails',
+	'l': 'likeCurrentTrack',
+	'd': 'dislikeCurrentTrack',
 }
 
 DEFAULT_QUIT_KEYBOARD_SHORTCUT = f'{DEFAULT_KEYBOARD_MODIFIERS}+q'
@@ -41,6 +43,8 @@ functionsToControls = {
 	'getCurrentTrackArtistNames': controls.getCurrentTrackArtistNames,
 	'getCurrentTrackAlbumName': controls.getCurrentTrackAlbumName,
 	'getCurrentTrackDetails': controls.getCurrentTrackDetails,
+	'likeCurrentTrack': controls.likeCurrentTrack,
+	'dislikeCurrentTrack': controls.dislikeCurrentTrack,
 }
 
 DEFAULT_JSON_CONFIG_PATH = 'data/config.json'


### PR DESCRIPTION
#### Description
This PR adds functionality to like and dislike the currently-playing track. If executing either command when the currently-playing track has already been liked or disliked, SpotKeys will tell you so, and therefore not act as a toggle.

#### Closed Issues
* Closes #46