### PR TITLE
Suppress keyboard shortcuts to the focused window

### DIFF
--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -47,7 +47,7 @@ def checkForPlayingMedia(function):
 			currentPlaybackContext = getCurrentPlaybackContext()
 			return function(currentPlaybackContext, *args, **kwargs)
 		except NoMediaPlayingError:
-			speech.say('No media playing')
+			speech.say('No media playing', interrupt=True)
 			return
 
 	return wrapper
@@ -96,10 +96,10 @@ def playOrPause(currentPlaybackContext) -> None:
 
 	if isPlaying:
 		spotifyHandler.pause_playback()
-		speech.say('Paused')
+		speech.say('Paused', interrupt=True)
 	else:
 		spotifyHandler.start_playback()
-		speech.say('Playing')
+		speech.say('Playing', interrupt=True)
 
 
 @checkForPlayingMedia
@@ -107,7 +107,7 @@ def previousTrack(currentPlaybackContext) -> None:
 	"""Moves to the previous track."""
 
 	spotifyHandler.previous_track()
-	speech.say('Previous track')
+	speech.say('Previous track', interrupt=True)
 
 
 @checkForPlayingMedia
@@ -115,7 +115,7 @@ def nextTrack(currentPlaybackContext) -> None:
 	"""Moves to the next track."""
 
 	spotifyHandler.next_track()
-	speech.say('Next track')
+	speech.say('Next track', interrupt=True)
 
 
 @checkForPlayingMedia
@@ -198,7 +198,7 @@ def decreaseVolume(currentPlaybackContext, percentage=VOLUME_PERCENTAGE_INTERVAL
 		newVolume = round(newVolume / percentage) * percentage
 
 		spotifyHandler.volume(newVolume)
-		speech.say(f'{newVolume}% volume')
+		speech.say(f'{newVolume}% volume', interrupt=True)
 
 
 @checkForPlayingMedia
@@ -222,7 +222,7 @@ def increaseVolume(currentPlaybackContext, percentage=VOLUME_PERCENTAGE_INTERVAL
 		newVolume = round(newVolume / percentage) * percentage
 
 		spotifyHandler.volume(newVolume)
-		speech.say(f'{newVolume}% volume')
+		speech.say(f'{newVolume}% volume', interrupt=True)
 
 
 @checkForPlayingMedia
@@ -233,10 +233,10 @@ def likeCurrentTrack(currentPlaybackContext) -> None:
 	trackName = track['name']
 
 	if spotifyHandler.current_user_saved_tracks_contains([trackID])[0]:
-		speech.say(f'{trackName} is already in your Liked Songs')
+		speech.say(f'{trackName} is already in your Liked Songs', interrupt=True)
 	else:
 		spotifyHandler.current_user_saved_tracks_add([trackID])
-		speech.say(f'Added {trackName} to Liked Songs')
+		speech.say(f'Added {trackName} to Liked Songs', interrupt=True)
 
 
 @checkForPlayingMedia
@@ -247,10 +247,10 @@ def dislikeCurrentTrack(currentPlaybackContext) -> None:
 	trackName = track['name']
 
 	if not spotifyHandler.current_user_saved_tracks_contains([trackID])[0]:
-		speech.say(f'{trackName} is not in your Liked Songs')
+		speech.say(f'{trackName} is not in your Liked Songs', interrupt=True)
 	else:
 		spotifyHandler.current_user_saved_tracks_delete([trackID])
-		speech.say(f'Removed {trackName} from Liked Songs')
+		speech.say(f'Removed {trackName} from Liked Songs', interrupt=True)
 
 
 @checkForPlayingMedia
@@ -270,32 +270,32 @@ def muteOrUnmute(currentPlaybackContext) -> None:
 	if currentVolume > 0:
 		APP_STATE['preMuteVolume'] = currentVolume
 		spotifyHandler.volume(0)
-		speech.say('Muted')
+		speech.say('Muted', interrupt=True)
 	else:
 		spotifyHandler.volume(APP_STATE['preMuteVolume'])
 		del APP_STATE['preMuteVolume']
-		speech.say('Unmuted')
+		speech.say('Unmuted', interrupt=True)
 
 
 @checkForPlayingMedia
 def getCurrentTrackName(currentPlaybackContext) -> None:
 	"""Gets the name of the currently-playing track."""
 
-	speech.say(getTrackName(currentPlaybackContext))
+	speech.say(getTrackName(currentPlaybackContext), interrupt=True)
 
 
 @checkForPlayingMedia
 def getCurrentTrackArtistNames(currentPlaybackContext) -> None:
 	"""Get the list of artist name(s) of the currently-playing track."""
 
-	speech.say(', '.join(getTrackArtistNames(currentPlaybackContext)))
+	speech.say(', '.join(getTrackArtistNames(currentPlaybackContext)), interrupt=True)
 
 
 @checkForPlayingMedia
 def getCurrentTrackAlbumName(currentPlaybackContext) -> None:
 	"""Gets the album name of the currently-playing track."""
 
-	speech.say(getTrackAlbumName(currentPlaybackContext))
+	speech.say(getTrackAlbumName(currentPlaybackContext), interrupt=True)
 
 
 @checkForPlayingMedia
@@ -311,7 +311,7 @@ def getCurrentTrackDetails(currentPlaybackContext) -> None:
 	artistNames = ', '.join(getTrackArtistNames(currentPlaybackContext))
 	albumName = getTrackAlbumName(currentPlaybackContext)
 
-	speech.say(f'{trackName} by {artistNames} from {albumName}')
+	speech.say(f'{trackName} by {artistNames} from {albumName}', interrupt=True)
 
 
 @checkForPlayingMedia
@@ -323,6 +323,6 @@ def copyCurrentTrackURL(currentPlaybackContext) -> None:
 	trackName = getTrackName(currentPlaybackContext)
 	trackID = getTrackID(currentPlaybackContext)
 
-	speech.say(f'URL copied to clipboard: {trackName}')
+	speech.say(f'URL copied to clipboard: {trackName}', interrupt=True)
 
 	pyperclip.copy(f'{TRACK_URL}/{trackID}')

--- a/spotKeys/core.py
+++ b/spotKeys/core.py
@@ -6,9 +6,9 @@ from spotKeys import controls, keyboardHandler, speech
 def initialize() -> None:
 	"""Initializes the core logic by initializing speech and registering keyboard shortcuts."""
 
+	keyboardHandler.registerKeyboardShortcuts()
 	speech.initialize()
 	speech.say('Spot Keys is ready')
-	keyboardHandler.registerKeyboardShortcuts()
 
 
 def run() -> None:

--- a/spotKeys/core.py
+++ b/spotKeys/core.py
@@ -8,7 +8,8 @@ def initialize() -> None:
 
 	keyboardHandler.registerKeyboardShortcuts()
 	speech.initialize()
-	speech.say('Spot Keys is ready')
+	speech.say('SpotKeys is ready.')
+	speech.say('Press alt+shift+f1 to open the help page.')
 
 
 def run() -> None:

--- a/spotKeys/keyboardHandler.py
+++ b/spotKeys/keyboardHandler.py
@@ -34,7 +34,7 @@ def registerKeyboardShortcuts() -> None:
 	"""Register built-in keyboard shortcuts with the keyboard library."""
 
 	for key, control in DEFAULT_KEYBOARD_SHORTCUTS.items():
-		keyboard.add_hotkey(f'{DEFAULT_KEYBOARD_MODIFIERS}+{key}', control)
+		keyboard.add_hotkey(f'{DEFAULT_KEYBOARD_MODIFIERS}+{key}', control, suppress=True)
 
 
 def waitForInput() -> None:

--- a/spotKeys/speech.py
+++ b/spotKeys/speech.py
@@ -9,10 +9,10 @@ def initialize() -> None:
 	tolk.load()
 
 
-def say(text: str) -> None:
+def say(text: str, interrupt: bool = False) -> None:
 	"""Speaks the given text with Tolk."""
 
-	tolk.speak(text)
+	tolk.speak(text, interrupt=interrupt)
 
 
 def isSpeaking() -> bool:


### PR DESCRIPTION
#### Description
This PR ensures that when pressing a SpotKeys keyboard shortcut, it isn't passed to the currently-focused window. This may introduce conflicts depending on the application in focus, but cross that bridge when we get to it.

The following work is featured:
- **Suppress keyboard shortcuts to active window**
- **Add `interrupt` flag to speech module**
- **Interrupt speech when announcing controls**
- **Move keyboard handler init before speech init**
- **Add startup announcement to convey help page**

I addressed speech interruptions in this PR, because I noticed a significant annoyance when navigating a UI like Chrome, Discord, etc, that continued to read speech, but wouldn't interrupt upon a SpotKeys command.

The help page announcement illustrated the need to control whether multiple speech calls interrupt, hence why it's collapsed into this PR and not in its own.

#### Closed Issues
* Closes #45