### PR TITLE
Include `manifest.json` in executable build

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -7,6 +7,7 @@ a = Analysis(
     binaries=[],
         datas=[
             ('vendor\\tolk-python\\tolk\\*.dll', '.'),
+            ('manifest.json', '.'),
         ],
     hiddenimports=[],
     hookspath=[],


### PR DESCRIPTION
#### Description
This PR simply includes `manifest.json` in `build.spec` so it's baked into the resulting executable.

#### Closed Issues
* Closes #68