### PR TITLE
Implement shuffle

### DIFF
--- a/spotKeys/controls.py
+++ b/spotKeys/controls.py
@@ -357,6 +357,25 @@ def cycleRepeat(currentPlaybackContext) -> None:
 		speech.say('You must be listening to a collection like an album, a playlist, etc.')
 
 
+@checkForPlayingMedia
+def toggleShuffle(currentPlaybackContext) -> None:
+	"""Toggles shuffle between on and off."""
+
+	shuffleState = currentPlaybackContext.get('shuffle_state')
+	newShuffleState = not shuffleState
+
+	try:
+		spotifyHandler.shuffle(newShuffleState)
+	except Exception:
+		speech.say('Shuffle is unavailable.')
+		return
+
+	if newShuffleState:
+		speech.say('Shuffle on')
+	else:
+		speech.say('Shuffle off')
+
+
 def checkForUpdate() -> None:
 	"""Checks if there's an available app update."""
 

--- a/spotKeys/keyboard.py
+++ b/spotKeys/keyboard.py
@@ -20,6 +20,7 @@ DEFAULT_KEYBOARD_SHORTCUTS: dict[str, Callable[[], None]] = {
 	']': controls.fastForward,
 	'm': controls.muteOrUnmute,
 	'e': controls.cycleRepeat,
+	's': controls.toggleShuffle,
 	'n': controls.getCurrentTrackName,
 	'r': controls.getCurrentTrackArtistNames,
 	'a': controls.getCurrentTrackAlbumName,


### PR DESCRIPTION
#### Description
This PR adds the ability to toggle shuffle on or off. It does not, however, offer the ability to toggle between smart and classic shuffle modes; that must be performed in the native Spotify client.

#### Closed Issues
* Closes #77